### PR TITLE
Add optional database loading and configurable guild id

### DIFF
--- a/src/config/config.yaml.example
+++ b/src/config/config.yaml.example
@@ -1,5 +1,7 @@
 config_mode: dev
 
+dev_guild: 747542543750660178
+
 # Bot settings
 bot:
   token: 

--- a/src/run.py
+++ b/src/run.py
@@ -9,7 +9,8 @@ import yaml
 
 from logger import BotLogger
 
-UIO_GAMING_GUILD_ID = 412646636771344395
+
+UIO_GAMING_GUILD_ID = 747542543750660178
 DATABASE_RELIANT_COGS = {
     "birthday.py",
     "gullkorn.py",

--- a/src/run.py
+++ b/src/run.py
@@ -36,7 +36,7 @@ class Bot(commands.Bot):
 
         self.logger = BotLogger().logger  # Initialize logger
 
-        self.guild_id = config.get("guild", UIO_GAMING_GUILD_ID)
+        self.guild_id = config.get("dev_guild", UIO_GAMING_GUILD_ID)
 
         # Connect to database
         db = config.get('database')


### PR DESCRIPTION
To make contributing and local running easier, 
this pr disables cogs that rely on a database connection.

To run database-free, simply remove the database section of the config.

To run bot in custom guild, add "guild: <guild-id>" at top level in config.yaml