### PR TITLE
Fixed math in coinflip()

### DIFF
--- a/src/cogs/misc.py
+++ b/src/cogs/misc.py
@@ -324,9 +324,9 @@ class Misc(commands.Cog):
         """
 
         random_result = random.randint(1, 100)  # We use 1 and not 0 to avoid a tie
-        if random_result >= 50:  # And by including 50 we avoid that tie
+        if random_result > 50:  # And by including 50 we avoid that tie
             outcome = "Kron"
-        elif random_result < 50:
+        elif random_result <= 50:
             outcome = "Mynt"
 
         await interaction.response.send_message(outcome)


### PR DESCRIPTION
☝️🤓

Per the `random` library documentation:
> `random.randint(a, b)`
>     Return a random integer N such that `a <= N <= b`. Alias for `randrange(a, b+1)`.

As such, the variable `random_result` returns an integer between 1 and 100 _inclusive_, and as such we need to assign numbers between 1 and 50 to `Kron` and between 51 and 100 to `Mynt` in order to achieve a fair result.

As the code exists right now, `coinflip()` returns `Kron` 51% of the time and `Mynt` 49% of the time, which isn't _perfectly_ fair